### PR TITLE
Prefer `t` over `request_time` if it exists

### DIFF
--- a/defaults/transform.js
+++ b/defaults/transform.js
@@ -48,7 +48,7 @@ module.exports = through.obj(
       method: obj.fields.method,
       code: obj.fields.code,
       bucket: p[1],
-      t: Math.floor(obj.fields.request_time * 1000) || 0,
+      t: (!!obj.fields.t ? obj.fields.t : Math.floor(obj.fields.request_time * 1000) || 0),
       ua_browser: obj.fields.user_agent_browser,
       ua_version: obj.fields.user_agent_version,
       ua_os: obj.fields.user_agent_os,


### PR DESCRIPTION
The `request_time` field use by sync predates the mozlog standard. The
preferred field is `t` which is the request time in milliseconds. This
makes transform.js compatible with modern mozlog used by the golang
implementation of sync storage as well as the proprietary one use by
python sync
